### PR TITLE
Explicitly add `types` field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "type": "module",
   "exports": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "author": {
     "name": "Rajas Paranjpe",
     "url": "https://github.com/ChocolateLoverRaj"


### PR DESCRIPTION
It doesn't work without it